### PR TITLE
Update tag.rb

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,4 +1,4 @@
-class Tag < DataMapper::Base
+class Tag < ActiveRecord::Base
   property :name, :string
   
   validates_uniqueness_of :name


### PR DESCRIPTION
DataMapper::Base should be ActiveRecord::Base if you are using Rails, as DataMapper is another Object Relational Mapping (ORM) library that is not part of Rails.